### PR TITLE
build correctly during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "license": "MIT",
     "scripts": {
         "build": "babel src --out-dir .",
-        "prepare": "cross-env NODE_ENV=production npm run build",
+        "prepare": "cross-env npm run build",
         "watch": "babel -w src --out-dir ."
     },
     "peerDependencies": {


### PR DESCRIPTION
This runs the babel build script when installing the package as a dependency. Prior to this, installing and configuring this package as a dependency results in a silent failure (or success, depending on how you look at it) when running `gatsby develop`. For some reason, gatsby just ignores this at the moment, throws no error and otherwise compiles successfully.