### PR TITLE
Cleanup logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ module.exports = {
                 include: [], // Array of form IDs. Will only import these forms.
                 exclude: [], // Array of form IDs. Will exclude these forms.
                 // Gravity Forms API
+                allowSelfSigned: false
                 api: {
                     key: 'CONSUMER_KEY',
                     secret: 'CONSUMER_SECRET',
@@ -56,6 +57,8 @@ module.exports = {
                     key: 'CONSUMER_KEY',
                     secret: 'CONSUMER_SECRET',
                 },
+                //Set to true to enable selfsigned certs in development mode
+                allowSelfSigned: false
                 // Basic Auth
                 basicAuth: {
                     username: 'USERNAME',

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module.exports = {
                     key: 'CONSUMER_KEY',
                     secret: 'CONSUMER_SECRET',
                 },
-                //Set to true to enable selfsigned certs in development mode
+                // Set to true to enable selfsigned certs in development mode
                 allowSelfSigned: false
                 // Basic Auth
                 basicAuth: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@babel/runtime": "^7.9.2",
         "axios": ">=0.19.2",
-        "chalk": "^4.0.0",
         "nanoid": "^3.1.3",
         "oauth-signature": "^1.5.0"
     },

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,19 +8,14 @@ const log = console.log
 let activeEnv =
     process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || 'development'
 
-// If we are in dev, ignore the fact that we are using a fake SSL certificate
-if (activeEnv == 'development') {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-}
-
 exports.sourceNodes = async (
     { actions: { createNode }, createContentDigest, createNodeId },
     {
-        plugins,
         baseUrl,
         api,
         include,
         exclude,
+        allowSelfSigned,
         basicAuth = {
             username: '',
             password: '',
@@ -28,6 +23,11 @@ exports.sourceNodes = async (
         ignoreFields = ['notifications'],
     }
 ) => {
+    // If we are in dev, ignore the fact that we are using a fake SSL certificate
+    if (activeEnv == 'development' && allowSelfSigned) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+    }
+
     log(chalk.black.bgWhite('Starting Gravity Forms Source plugin'))
 
     // Run initial checks

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,15 +1,11 @@
-const chalk = require('chalk')
-
 const { getFormsAndFields } = require('./utils/axios')
 const { processForms } = require('./utils/processForms')
-
-const log = console.log
 
 let activeEnv =
     process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || 'development'
 
 exports.sourceNodes = async (
-    { actions: { createNode }, createContentDigest, createNodeId },
+    { actions: { createNode }, createContentDigest, createNodeId, reporter },
     {
         baseUrl,
         api,
@@ -23,25 +19,28 @@ exports.sourceNodes = async (
         ignoreFields = ['notifications'],
     }
 ) => {
+    global.reporter = reporter;
     // If we are in dev, ignore the fact that we are using a fake SSL certificate
     if (activeEnv == 'development' && allowSelfSigned) {
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
     }
 
-    log(chalk.black.bgWhite('Starting Gravity Forms Source plugin'))
+    reporter.verbose('Starting Gravity Forms Source plugin')
 
     // Run initial checks
     if (!baseUrl) {
-        log(chalk.bgRed('We could not find a baseUrl in your gatsby-config.js'))
+        reporter.panic(
+            'We could not find a baseUrl in your gatsby-config.js',
+            new Error('Missing baseURL in config')
+        )
         return
     }
-    log(`Using: ${baseUrl}`)
+    reporter.verbose(`Using: ${baseUrl}`)
 
     if (!api.key || !api.secret) {
-        log(
-            chalk.bgRed(
-                'You seem to be missing Gravity Forms API details in your gatsby-config.js'
-            )
+        reporter.panic(
+            'You seem to be missing Gravity Forms API details in your gatsby-config.js',
+            new Error('Misisng api keys in config')
         )
         return
     }
@@ -63,9 +62,10 @@ exports.sourceNodes = async (
     // Check to make sure we got forms. If issues occured
     // need to stop here
     if (formsObj) {
-        log(chalk.black.bgWhite('Processing forms'))
+        const entriesArr = Object.entries(formsObj)
+        reporter.info(`Processing ${entriesArr.length} Gravity Forms`)
 
-        for (const [key, value] of Object.entries(formsObj)) {
+        for (const [key, value] of entriesArr) {
             createNode(
                 processForms(
                     createContentDigest,
@@ -76,6 +76,6 @@ exports.sourceNodes = async (
             )
         }
 
-        log(chalk.black.bgWhite('Completed Gravity Forms Source plugin'))
+        reporter.verbose('Completed Gravity Forms Source plugin')
     }
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -11,7 +11,7 @@ exports.sourceNodes = async (
         api,
         include,
         exclude,
-        allowSelfSigned,
+        allowSelfSigned = false,
         basicAuth = {
             username: '',
             password: '',

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -1,16 +1,12 @@
 const axios = require('axios')
-const chalk = require('chalk')
 const oauthSignature = require('oauth-signature')
-
 const { routes } = require('./routes')
 const { isObjEmpty, slugify } = require('./helpers')
 const { new0AuthParameters } = require('./oAuthParameters')
 
-const log = console.log
-
 // Get list of all forms from GF
 async function getForms(basicAuth, api, baseUrl) {
-    log(chalk.black.bgWhite('Fetching form ids'))
+    reporter.verbose('Fetching form ids')
 
     const authParams = new0AuthParameters(api.key)
 
@@ -46,7 +42,7 @@ async function getForms(basicAuth, api, baseUrl) {
 
 // Get form fields from GF
 async function getFormFields(basicAuth, api, baseUrl, form) {
-    log(chalk.black.bgWhite(`Fetching fields for form ${form.id}`))
+    reporter.verbose(`Fetching fields for form ${form.id}`)
 
     let authParams = new0AuthParameters(api.key)
 
@@ -103,12 +99,12 @@ async function getFormsAndFields(basicAuth, api, baseUrl, formsArgs) {
                 let currentFormId = parseInt(currentForm.id)
 
                 // If include is defined with form IDs, only include these form IDs.
-                if ( formsArgs.include && !formsArgs.include.includes(currentFormId) ) {
+                if (formsArgs.include && !formsArgs.include.includes(currentFormId)) {
                     continue
                 }
 
                 // If exclude is defined with form IDs, don't include these form IDs.
-                if ( formsArgs.exclude && formsArgs.exclude.includes(currentFormId) ) {
+                if (formsArgs.exclude && formsArgs.exclude.includes(currentFormId)) {
                     continue
                 }
 
@@ -119,13 +115,13 @@ async function getFormsAndFields(basicAuth, api, baseUrl, formsArgs) {
                     basicAuth,
                     api,
                     baseUrl,
-                    currentForm
+                    currentForm,
                 )
 
                 formObj['form-' + currentForm.id] = form
             }
         } else {
-            log(chalk.bgRed('We could not find any forms. Have you made any?'))
+            reporter.error('We could not find any forms. Have you made any?')
         }
 
         return formObj
@@ -137,20 +133,30 @@ function apiErrorHandler(error) {
     if (error.response) {
         // The request was made and the server responded with a status code
         // that falls out of the range of 2xx
-        log(chalk.bgRed('Request was made, but there was an issue'))
-        log(error.response.data)
-        log(error.response.status)
-        log(error.response.headers)
+        reporter.panicOnBuild(
+            'Request was made, but there was an issue',
+            new Error(`Error ${error.response.status} from GraityForms API`)
+        )
+
+        // log(error.response.data)
+        // log(error.response.status)
+        // log(error.response.headers)
     } else if (error.request) {
         // The request was made but no response was received
         // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
         // http.ClientRequest in node.js
-        log(chalk.bgRed('Request was made, but no response'))
-        log(error.request)
+        reporter.panicOnBuild(
+            'Request was made, but no response',
+            new Error('No Repsonse from GraityForms API')
+        )
+        // log(error.request)
     } else {
         // Something happened in setting up the request that triggered an Error
-        log(chalk.bgRed('Something happened setting up the request'))
-        log('Error', error)
+        reporter.panicOnBuild(
+            'Something happened setting up the request',
+            new Error('Unsure of GraityForms API Error')
+        )
+        // log('Error', error)
     }
 }
 

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -135,7 +135,7 @@ function apiErrorHandler(error) {
         // that falls out of the range of 2xx
         reporter.panicOnBuild(
             'Request was made, but there was an issue',
-            new Error(`Error ${error.response.status} from GraityForms API`)
+            new Error(`Error ${error.response.status} from GravityForms API`)
         )
 
         // log(error.response.data)
@@ -147,14 +147,14 @@ function apiErrorHandler(error) {
         // http.ClientRequest in node.js
         reporter.panicOnBuild(
             'Request was made, but no response',
-            new Error('No Repsonse from GraityForms API')
+            new Error('No Repsonse from GravityForms API')
         )
         // log(error.request)
     } else {
         // Something happened in setting up the request that triggered an Error
         reporter.panicOnBuild(
             'Something happened setting up the request',
-            new Error('Unsure of GraityForms API Error')
+            new Error('Unsure of GravityForms API Error')
         )
         // log('Error', error)
     }


### PR DESCRIPTION
Using this source plugin created a lot of noise in builds. Lots of logs and a big warning from node about self signed certs. I added a plugin option to enable the self-seigned certs so it's not pointlessly noisy. I also reworked the logging to use Gatsby's internal reporter. 

I've reduced regular logging to a single line. If running Gatsby with `--verbose` there will be more logging, and finally important config issues or a non responsive api will panic/panicOnBuild. I went back and forth on how much to use panic, so I'm happy to use it less if you feel that's appropriate. 

Hopefully this is all helpful, let me know if you'd like any changes.

https://www.gatsbyjs.org/docs/node-api-helpers/#reporter