### PR TITLE
Add option to pass include and exclude form IDs from query

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ module.exports = {
             options: {
                 // Base URL needs to include protocol (http/https)
                 baseUrl: 'SITE_BASE_URL',
+                include: [], // Array of form IDs. Will only import these forms.
+                exclude: [], // Array of form IDs. Will exclude these forms.
                 // Gravity Forms API
                 api: {
                     key: 'CONSUMER_KEY',

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -19,6 +19,8 @@ exports.sourceNodes = async (
         plugins,
         baseUrl,
         api,
+        include,
+        exclude,
         basicAuth = {
             username: '',
             password: '',
@@ -44,9 +46,19 @@ exports.sourceNodes = async (
         return
     }
 
+    let formsArgs = {}
+
+    if (Array.isArray(include) && include.length) {
+        formsArgs.include = include
+    }
+
+    if (Array.isArray(exclude) && exclude.length) {
+        formsArgs.exclude = exclude
+    }
+
     // Get a full object of forms and fields
 
-    let formsObj = await getFormsAndFields(basicAuth, api, baseUrl)
+    let formsObj = await getFormsAndFields(basicAuth, api, baseUrl, formsArgs)
 
     // Check to make sure we got forms. If issues occured
     // need to stop here

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -87,7 +87,7 @@ async function getFormFields(basicAuth, api, baseUrl, form) {
     return result.data
 }
 
-async function getFormsAndFields(basicAuth, api, baseUrl) {
+async function getFormsAndFields(basicAuth, api, baseUrl, formsArgs) {
     let formObj = {}
 
     // First get forms in list
@@ -99,6 +99,18 @@ async function getFormsAndFields(basicAuth, api, baseUrl) {
             for (const [key, value] of Object.entries(allForms)) {
                 // Clone form object
                 let currentForm = { ...allForms[key] }
+
+                let currentFormId = parseInt(currentForm.id)
+
+                // If include is defined with form IDs, only include these form IDs.
+                if ( formsArgs.include && !formsArgs.include.includes(currentFormId) ) {
+                    continue
+                }
+
+                // If exclude is defined with form IDs, don't include these form IDs.
+                if ( formsArgs.exclude && formsArgs.exclude.includes(currentFormId) ) {
+                    continue
+                }
 
                 // remove unneeded key
                 delete currentForm.entries


### PR DESCRIPTION
Hi! Thanks for the great plugin.

Right now all active forms are queried and passed into nodes but I'd love to be able to set IDs to include or exclude from the query.

Thanks!