### PR TITLE
Add pagination to formSchema

### DIFF
--- a/src/schema/formSchema.js
+++ b/src/schema/formSchema.js
@@ -10,5 +10,6 @@ export const formSchema = {
     },
     notifications: '',
     confirmations: '',
+    pagination: '',
     apiURL: '',
 }


### PR DESCRIPTION
Great plugin - thanks for all your hard work!

I have a project with some multi-page forms. In the future, it might be worth exploring a way to get the fields back pre-paginated (an array of pages, with their corresponding fields), but for now this allows you to list the page titles, and correspond them to the fields `pageNumber` attribute pretty easily.