### PR TITLE
Add missing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module.exports = {
                 include: [], // Array of form IDs. Will only import these forms.
                 exclude: [], // Array of form IDs. Will exclude these forms.
                 // Gravity Forms API
-                allowSelfSigned: false
+                allowSelfSigned: false,
                 api: {
                     key: 'CONSUMER_KEY',
                     secret: 'CONSUMER_SECRET',
@@ -58,7 +58,7 @@ module.exports = {
                     secret: 'CONSUMER_SECRET',
                 },
                 // Set to true to enable selfsigned certs in development mode
-                allowSelfSigned: false
+                allowSelfSigned: false,
                 // Basic Auth
                 basicAuth: {
                     username: 'USERNAME',


### PR DESCRIPTION
Commas were missing from the Gatsby config instructions.