### PR TITLE
(fix) IE11 Support - Removes Nanoid, uses crypto algorithm for nouce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gatsby-source-gravityforms",
     "description": "Gatsby source plugin to add WordPress Gravity Forms nodes to your app.",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "author": "Robert Marshall (https://robertmarshall.dev)",
     "dependencies": {
         "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@babel/runtime": "^7.12.5",
         "axios": ">=0.21.0",
-        "nanoid": "^3.1.20",
         "oauth-signature": "^1.5.0"
     },
     "keywords": [

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,4 +1,4 @@
-const { nanoid } = require('nanoid')
+const { createHmac } = require('crypto')
 
 /**
  * Destructure array and turn to string.
@@ -49,6 +49,11 @@ function isBool(val) {
     return false
 }
 
+function createHash() {
+    const hmac = createHmac('sha1', Math.random().toString(36).substring(7));
+    return hmac.update(Buffer.from(Math.random().toString(36).substring(7), 'utf-8')).digest('hex');
+}
+
 /**
  * A function to create 0Auth parameters. Ensuring timestamp and
  * nonce are aways as new as possible.
@@ -61,7 +66,7 @@ function new0AuthParameters(consumerKey) {
         oauth_timestamp: getCurrentTimestamp(),
         oauth_signature_method: 'HMAC-SHA1',
         oauth_version: '1.0',
-        oauth_nonce: nanoid(11),
+        oauth_nonce: createHash(),
     }
 }
 


### PR DESCRIPTION
Gatsby's browser support is the same as React which means it should be able to handle IE9 and up.

Support for IE 11 is broken due to the NanoID dependency used to create nouce. In order to get the support they require transforming their code through Babel. https://github.com/ai/nanoid#ie

Instead of doing that it was opted to just create the nouce on the fly. Should provide required security via randomizer. 